### PR TITLE
Ideology bugfixes

### DIFF
--- a/Source/DynamicTradeInterface/UserInterface/Columns/ColumnCaption.cs
+++ b/Source/DynamicTradeInterface/UserInterface/Columns/ColumnCaption.cs
@@ -33,7 +33,7 @@ namespace DynamicTradeInterface.UserInterface.Columns
 				float joinAsWidth = 0;
 				if (ModsConfig.IdeologyActive && row.AnyThing is Pawn pawn)
 				{
-					if (pawn.RaceProps.Humanlike && pawn.guest != null && pawn.Faction.IsPlayer == false)
+					if (pawn.RaceProps.Humanlike && pawn.guest != null && !pawn.IsPrisonerOfColony && !pawn.IsSlaveOfColony)
 					{
 						joinAsLabel = (pawn.guest.joinStatus == JoinStatus.JoinAsColonist ? "JoinsAsColonist" : "JoinsAsSlave").Translate();
 						joinAsDesc = (pawn.guest.joinStatus == JoinStatus.JoinAsColonist ? "JoinsAsColonistDesc" : "JoinsAsSlaveDesc").Translate();

--- a/Source/DynamicTradeInterface/UserInterface/Columns/ColumnExtraIcons.cs
+++ b/Source/DynamicTradeInterface/UserInterface/Columns/ColumnExtraIcons.cs
@@ -166,24 +166,23 @@ namespace DynamicTradeInterface.UserInterface.Columns
 				return;
 
 			Rect iconRect = new Rect(curX, rect.y, rect.height, rect.height).ContractedBy(1);
-			iconRect.x -= iconRect.width;
 
 			if (cache.Captive)
 			{
 				if (cache.TraderHomeFaction)
 				{
-					GUI.DrawTexture(rect, GuestUtility.RansomIcon);
-					if (Mouse.IsOver(rect))
+					GUI.DrawTexture(iconRect, GuestUtility.RansomIcon);
+					if (Mouse.IsOver(iconRect))
 					{
 						TooltipHandler.TipRegion(rect, "SellingAsRansom".Translate());
 					}
 				}
 				else
 				{
-					GUI.DrawTexture(rect, GuestUtility.SlaveIcon);
-					if (Mouse.IsOver(rect))
+					GUI.DrawTexture(iconRect, GuestUtility.SlaveIcon);
+					if (Mouse.IsOver(iconRect))
 					{
-						TooltipHandler.TipRegion(rect, "SellingAsSlave".Translate());
+						TooltipHandler.TipRegion(iconRect, "SellingAsSlave".Translate());
 					}
 				}
 				iconRect.x -= iconRect.width;


### PR DESCRIPTION
* When the colony has a prisoner with a null faction (which is possible if you imprison from a minor faction like beggars or sanguophages) the pawn.Faction.IsPlayer check in ColumnCaption would trigger a NullReferenceException.

* Prevent the 'Joins as slave' caption from being shown on pawns that are prisoners or slaves of the colony.

* Prevent the ColumnExtraIcon for Ideology from being drawn over Biotech icons as a rectangle with expanded width.

Before the changes:

![imagen](https://github.com/Zeracronius/DynamicTradeInterface/assets/3092211/521e7a11-cc24-4aff-b635-bfa97b63d12f)

After the changes:

![imagen](https://github.com/Zeracronius/DynamicTradeInterface/assets/3092211/6cb8633b-790a-48eb-9d6e-377d507ff6b6)
