### PR TITLE
Add support for Random's Gene Assistant

### DIFF
--- a/Source/DynamicTradeInterface/InterfaceComponents/GeneAssistant.cs
+++ b/Source/DynamicTradeInterface/InterfaceComponents/GeneAssistant.cs
@@ -1,0 +1,111 @@
+﻿using System.Linq;
+using UnityEngine;
+using Verse;
+
+namespace DynamicTradeInterface.InterfaceComponents
+{
+	[StaticConstructorOnStartup]
+	internal static class GeneAssistant
+	{
+		private static readonly Texture2D? _missingIcon;
+		private static readonly Texture2D? _mixedIcon;
+		private static readonly Texture2D? _isolatedIcon;
+
+		public static readonly bool Active;
+
+		public enum GeneType
+		{
+			None,
+			Missing,
+			Mixed,
+			Isolated,
+		}
+
+		static GeneAssistant()
+		{
+			Active = ModsConfig.BiotechActive && ModsConfig.IsActive("rimworld.randomcoughdrop.geneassistant");
+			if (Active)
+			{
+				var genepack = ContentFinder<Texture2D>.Get("Things/Item/Special/Genepack/Genepack_e");
+				if (genepack != null)
+				{
+					_missingIcon = CreateTexture(genepack, GeneType.Missing);
+					_mixedIcon = CreateTexture(genepack, GeneType.Mixed);
+					_isolatedIcon = CreateTexture(genepack, GeneType.Isolated);
+				}
+			}
+		}
+
+		public static Texture2D? IconFor(GeneType type)
+		{
+			switch (type)
+			{
+				case GeneType.Missing:
+					return _missingIcon;
+				case GeneType.Mixed:
+					return _mixedIcon;
+				case GeneType.Isolated:
+					return _isolatedIcon;
+				default:
+					return null;
+			}
+		}
+
+		private static Texture2D CreateTexture(Texture2D source, GeneType type)
+		{
+			var texture = CreateReadableBaseTexture(source);
+
+			Color32 blend = default;
+			switch (type)
+			{
+				case GeneType.Missing:
+					blend = new Color32(255, 0, 0, 1);
+					break;
+				case GeneType.Mixed:
+					blend = new Color32(255, 255, 0, 1);
+					break;
+				case GeneType.Isolated:
+					blend = new Color32(0, 255, 0, 1);
+					break;
+			}
+
+			for (int mip = 0; mip < texture.mipmapCount; ++mip)
+			{
+				var pixels = texture.GetPixels32(mip)
+					.Select((c) => Color32.Lerp(c, blend, 0.5f))
+					.ToArray();
+				texture.SetPixels32(pixels, mip);
+			}
+			texture.Apply();
+
+			return texture;
+		}
+
+		private static Texture2D CreateReadableBaseTexture(Texture2D source)
+		{
+			// https://github.com/SmashPhil/SmashTools/blob/6d084a8aff0eb15128033af81e8b3c0a5f8a366f/SmashTools/SmashTools/Utility/Extensions/Game/Ext_Texture.cs#L72
+
+			var temp = RenderTexture.GetTemporary(
+				source.width,
+				source.height,
+				0,
+				RenderTextureFormat.Default,
+				RenderTextureReadWrite.Linear);
+			Graphics.Blit(source, temp);
+			var previous = RenderTexture.active;
+			RenderTexture.active = temp;
+
+			Texture2D result = new Texture2D(source.width, source.height) {
+				name = source.name
+			};
+
+			result.ReadPixels(new Rect(0, 0, temp.width, temp.height), 0, 0);
+			result.Apply();
+
+			RenderTexture.active = previous;
+			RenderTexture.ReleaseTemporary(temp);
+
+			return result;
+		}
+	}
+}

--- a/Source/DynamicTradeInterface/UserInterface/Columns/ColumnExtraIcons.cs
+++ b/Source/DynamicTradeInterface/UserInterface/Columns/ColumnExtraIcons.cs
@@ -1,193 +1,281 @@
-﻿using DynamicTradeInterface.Mod;
+﻿using DynamicTradeInterface.InterfaceComponents;
+using DynamicTradeInterface.Mod;
 using RimWorld;
 using RimWorld.Planet;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using Verse;
 
 namespace DynamicTradeInterface.UserInterface.Columns
 {
-	internal class ColumnExtraIcons
+	internal static class EnumerableExt
 	{
-		private struct Cache
+		public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> source)
 		{
-			public Pawn Pawn;
-			public Intelligence Intelligence;
-			public bool Rideable;
-			public bool Bonded;
-			public bool Pregnant;
-			public bool Sick;
-			public bool IsColonyMech;
-			public Pawn OverseerPawn;
-			public bool Captive;
-			public bool PlayerFaction;
-			public bool TraderHomeFaction;
+			foreach (IEnumerable<T> outer in source)
+				foreach (T inner in outer)
+					yield return inner;
 		}
 
-		private static Dictionary<Tradeable, Cache> _rowCache = new Dictionary<Tradeable, Cache>();
-
-		public static void PostOpen(IEnumerable<Tradeable> rows, Transactor transactor)
+		public static IEnumerable<TResult> SelectNotNull<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult?> selector)
 		{
-			foreach (var row in rows)
+			foreach (TSource elem in source)
 			{
-				if (row.AnyThing is Pawn pawn != true)
-					continue;
+				TResult? result = selector(elem);
+				if (result != null)
+					yield return result;
+			}
+		}
+	}
 
-				if (_rowCache.ContainsKey(row))
-					continue;
+	internal class ColumnExtraIcons
+	{
+		private abstract class ITradeable
+		{
+			public abstract void Draw(ref Rect rect, Tradeable row, Transactor transactor, ref bool refresh);
+		}
 
+		private class PawnTradeable : ITradeable
+		{
+			private Pawn _pawn;
+			private Intelligence _intelligence;
+			private bool _rideable;
+			private bool _bonded;
+			private bool _pregnant;
+			private bool _sick;
+			private bool _isColonyMech;
+			private Pawn _overseerPawn;
+			private bool _captive;
+			private bool _playerFaction;
+			private bool _traderHomeFaction;
+
+			public PawnTradeable(Tradeable tradeable, Pawn pawn)
+			{
 				string joinAsText = (pawn.guest?.joinStatus == JoinStatus.JoinAsColonist ? "JoinsAsColonist" : "JoinsAsSlave").Translate();
-				Cache cache = new Cache
-				{
-					Pawn = pawn,
-					Intelligence = pawn.RaceProps.intelligence,
-					Rideable = pawn.IsCaravanRideable(),
-					Bonded = pawn.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Bond) != null,
-					Pregnant = pawn.health.hediffSet.HasHediff(HediffDefOf.Pregnant, mustBeVisible: true),
-					Sick = pawn.health.hediffSet.AnyHediffMakesSickThought,
-					IsColonyMech = pawn.IsColonyMech,
-					OverseerPawn = pawn.GetOverseer(),
-					Captive = TransferableUIUtility.TransferableIsCaptive(row),
-					PlayerFaction = pawn.Faction?.IsPlayer ?? false,
-					TraderHomeFaction = pawn.HomeFaction == TradeSession.trader?.Faction,
-				};
+				_pawn = pawn;
+				_intelligence = pawn.RaceProps.intelligence;
+				_rideable = pawn.IsCaravanRideable();
+				_bonded = pawn.relations.GetFirstDirectRelationPawn(PawnRelationDefOf.Bond) != null;
+				_pregnant = pawn.health.hediffSet.HasHediff(HediffDefOf.Pregnant, mustBeVisible: true);
+				_sick = pawn.health.hediffSet.AnyHediffMakesSickThought;
+				_isColonyMech = pawn.IsColonyMech;
+				_overseerPawn = pawn.GetOverseer();
+				_captive = TransferableUIUtility.TransferableIsCaptive(tradeable);
+				_playerFaction = pawn.Faction?.IsPlayer ?? false;
+				_traderHomeFaction = pawn.HomeFaction == TradeSession.trader?.Faction;
+			}
 
-				_rowCache[row] = cache;
+			public override void Draw(ref Rect rect, Tradeable row, Transactor transactor, ref bool refresh)
+			{
+				float curX = rect.xMax;
+
+				if (_intelligence == Intelligence.Animal)
+					DoAnimalIcons(ref rect, ref curX);
+
+				if (ModsConfig.BiotechActive)
+					DoBiotechIcons(ref rect, ref curX);
+
+				if (ModsConfig.IdeologyActive)
+					DoIdeologyIcons(ref rect, ref curX);
+			}
+
+			private void DoAnimalIcons(ref Rect rect, ref float curX)
+			{
+				Rect iconRect = new Rect(curX, rect.y, rect.height, rect.height).ContractedBy(1);
+				iconRect.x -= iconRect.width;
+				if (_rideable)
+				{
+					GUI.DrawTexture(iconRect, Textures.RideableIcon);
+					if (Mouse.IsOver(iconRect))
+						TooltipHandler.TipRegion(iconRect, CaravanRideableUtility.GetIconTooltipText(_pawn));
+
+					iconRect.x -= iconRect.width;
+				}
+
+				if (_bonded)
+				{
+					TransferableUIUtility.DrawBondedIcon(_pawn, iconRect);
+					iconRect.x -= iconRect.width;
+				}
+
+				if (_pregnant)
+				{
+					TransferableUIUtility.DrawPregnancyIcon(_pawn, iconRect);
+					iconRect.x -= iconRect.width;
+				}
+
+				if (_sick)
+				{
+					if (Mouse.IsOver(iconRect))
+					{
+						IEnumerable<string> entries = _pawn.health.hediffSet.hediffs.Where(x => x.def.makesSickThought).Select(x => x.LabelCap);
+						TooltipHandler.TipRegion(iconRect, "CaravanAnimalSick".Translate() + ":\n\n" + entries.ToLineList(" - "));
+					}
+					GUI.DrawTexture(iconRect, Textures.SickIcon);
+					iconRect.x -= iconRect.width;
+				}
+
+				curX = iconRect.x;
+			}
+
+			private void DoBiotechIcons(ref Rect rect, ref float curX)
+			{
+				Rect iconRect = new Rect(curX, rect.y, rect.height, rect.height).ContractedBy(1);
+				iconRect.x -= iconRect.width;
+
+				if (_isColonyMech)
+				{
+					if (_overseerPawn != null)
+					{
+						GUI.DrawTexture(rect, PortraitsCache.Get(_overseerPawn, new Vector2(rect.width, rect.height), Rot4.South));
+						if (Mouse.IsOver(rect))
+						{
+							Widgets.DrawHighlight(rect);
+							TooltipHandler.TipRegion(rect, "MechOverseer".Translate(_overseerPawn));
+						}
+						iconRect.x -= iconRect.width;
+					}
+				}
+
+				XenotypeDef? xeno = _pawn.genes?.Xenotype;
+				if (xeno != null && xeno != XenotypeDefOf.Baseliner)
+				{
+					Widgets.DrawTextureFitted(iconRect, xeno.Icon, 1);
+					if (Mouse.IsOver(iconRect))
+						TooltipHandler.TipRegion(iconRect, xeno.LabelCap);
+
+					iconRect.x -= iconRect.width;
+				}
+
+				curX = iconRect.x;
+			}
+
+			private void DoIdeologyIcons(ref Rect rect, ref float curX)
+			{
+				if (_pawn.guest == null)
+					return;
+
+				Rect iconRect = new Rect(curX, rect.y, rect.height, rect.height).ContractedBy(1);
+				iconRect.x -= iconRect.width;
+
+				if (_captive)
+				{
+					if (_traderHomeFaction)
+					{
+						GUI.DrawTexture(rect, GuestUtility.RansomIcon);
+						if (Mouse.IsOver(rect))
+							TooltipHandler.TipRegion(rect, "SellingAsRansom".Translate());
+					}
+					else
+					{
+						GUI.DrawTexture(rect, GuestUtility.SlaveIcon);
+						if (Mouse.IsOver(rect))
+							TooltipHandler.TipRegion(rect, "SellingAsSlave".Translate());
+					}
+					iconRect.x -= iconRect.width;
+				}
 			}
 		}
 
+		private class GenepackTradeable : ITradeable
+		{
+			private static Dictionary<GeneDef, GeneAssistant.GeneType> _bankedGenes = new Dictionary<GeneDef, GeneAssistant.GeneType>();
+
+			private GeneAssistant.GeneType _geneType = GeneAssistant.GeneType.None;
+
+			private Texture? Icon => GeneAssistant.IconFor(_geneType);
+
+			public static void PostOpen(IEnumerable<Tradeable> rows, Transactor transactor)
+			{
+				if (transactor != Transactor.Colony)
+					return;
+
+				var genepacks = Find.CurrentMap
+					?.listerBuildings
+					.AllBuildingsColonistOfDef(ThingDefOf.GeneBank)
+					.SelectNotNull((building) => building.TryGetComp<CompGenepackContainer>()?.ContainedGenepacks)
+					.Flatten()
+					.SelectNotNull((genepack) => genepack.GeneSet?.GenesListForReading);
+				if (genepacks != null)
+				{
+					foreach (var genes in genepacks)
+					{
+						if (genes.Count == 1)
+							_bankedGenes[genes[0]] = GeneAssistant.GeneType.Isolated;
+						else
+							foreach (var gene in genes)
+								_bankedGenes.TryAdd(gene, GeneAssistant.GeneType.Mixed);
+					}
+				}
+			}
+
+			public static void PostClosed(IEnumerable<Tradeable> rows, Transactor transactor)
+			{
+				if (transactor == Transactor.Colony)
+					_bankedGenes.Clear();
+			}
+
+			public GenepackTradeable(Tradeable tradeable, Genepack genepack)
+			{
+				var types = genepack.GeneSet
+					?.GenesListForReading
+					.Select((gene) => _bankedGenes.TryGetValue(gene, GeneAssistant.GeneType.Missing))
+					.Distinct()
+					.ToList();
+				if (types?.Count > 0)
+				{
+					if (types.Any((x) => x == GeneAssistant.GeneType.Missing))
+						_geneType = GeneAssistant.GeneType.Missing;
+					else if (types.All((x) => x == GeneAssistant.GeneType.Isolated))
+						_geneType = GeneAssistant.GeneType.Isolated;
+					else
+						_geneType = GeneAssistant.GeneType.Mixed;
+				}
+			}
+
+			public override void Draw(ref Rect rect, Tradeable row, Transactor transactor, ref bool refresh)
+			{
+				var icon = Icon;
+				if (icon != null)
+				{
+					Rect iconRect = new Rect(rect.xMax - rect.height, rect.y, rect.height, rect.height).ContractedBy(1);
+					GUI.DrawTexture(iconRect, icon);
+				}
+			}
+		}
+
+		private static Dictionary<Tradeable, ITradeable> _rowCache = new Dictionary<Tradeable, ITradeable>();
+
+		public static void PostOpen(IEnumerable<Tradeable> rows, Transactor transactor)
+		{
+			if (GeneAssistant.Active)
+				GenepackTradeable.PostOpen(rows, transactor);
+
+			foreach (var row in rows)
+			{
+				if (!_rowCache.ContainsKey(row))
+				{
+					if (row.AnyThing is Pawn pawn)
+						_rowCache[row] = new PawnTradeable(row, pawn);
+					else if (row.AnyThing is Genepack genepack && GeneAssistant.Active)
+						_rowCache[row] = new GenepackTradeable(row, genepack);
+				}
+			}
+		}
 
 		public static void PostClosed(IEnumerable<Tradeable> rows, Transactor transactor)
 		{
+			if (GeneAssistant.Active)
+				GenepackTradeable.PostClosed(rows, transactor);
 			_rowCache.Clear();
 		}
 
 		public static void Draw(ref Rect rect, Tradeable row, Transactor transactor, ref bool refresh)
 		{
-			if (_rowCache.TryGetValue(row, out var cache) == false)
-				return;
-			
-			float curX = rect.xMax;
-
-
-			if (cache.Intelligence == Intelligence.Animal)
-			{
-				DoAnimalIcons(ref rect, ref curX, cache);
-			}
-			
-			if (ModsConfig.BiotechActive)
-			{
-				DoBiotechIcons(ref rect, ref curX, cache);
-			}
-
-			if (ModsConfig.IdeologyActive)
-			{
-				DoIdeologyIcons(ref rect, ref curX, cache);
-			}
-		}
-		private static void DoAnimalIcons(ref Rect rect, ref float curX, Cache cache)
-		{
-			Rect iconRect = new Rect(curX, rect.y, rect.height, rect.height).ContractedBy(1);
-			iconRect.x -= iconRect.width;
-			if (cache.Rideable)
-			{
-				GUI.DrawTexture(iconRect, Textures.RideableIcon);
-				if (Mouse.IsOver(iconRect))
-					TooltipHandler.TipRegion(iconRect, CaravanRideableUtility.GetIconTooltipText(cache.Pawn));
-
-				iconRect.x -= iconRect.width;
-			}
-
-			if (cache.Bonded)
-			{
-				TransferableUIUtility.DrawBondedIcon(cache.Pawn, iconRect);
-				iconRect.x -= iconRect.width;
-			}
-
-			if (cache.Pregnant)
-			{
-				TransferableUIUtility.DrawPregnancyIcon(cache.Pawn, iconRect);
-				iconRect.x -= iconRect.width;
-			}
-
-			if (cache.Sick)
-			{
-				if (Mouse.IsOver(iconRect))
-				{
-					IEnumerable<string> entries = cache.Pawn.health.hediffSet.hediffs.Where(x => x.def.makesSickThought).Select(x => x.LabelCap);
-					TooltipHandler.TipRegion(iconRect, "CaravanAnimalSick".Translate() + ":\n\n" + entries.ToLineList(" - "));
-				}
-				GUI.DrawTexture(iconRect, Textures.SickIcon);
-				iconRect.x -= iconRect.width;
-			}
-
-			curX = iconRect.x;
-		}
-
-		private static void DoBiotechIcons(ref Rect rect, ref float curX, Cache cache)
-		{
-			Rect iconRect = new Rect(curX, rect.y, rect.height, rect.height).ContractedBy(1);
-			iconRect.x -= iconRect.width;
-
-			if (cache.IsColonyMech)
-			{
-				if (cache.OverseerPawn != null)
-				{
-					GUI.DrawTexture(rect, PortraitsCache.Get(cache.OverseerPawn, new Vector2(rect.width, rect.height), Rot4.South));
-					if (Mouse.IsOver(rect))
-					{
-						Widgets.DrawHighlight(rect);
-						TooltipHandler.TipRegion(rect, "MechOverseer".Translate(cache.OverseerPawn));
-					}
-					iconRect.x -= iconRect.width;
-				}
-			}
-
-			XenotypeDef? xeno = cache.Pawn.genes?.Xenotype;
-			if (xeno != null && xeno != XenotypeDefOf.Baseliner)
-			{
-				Widgets.DrawTextureFitted(iconRect, xeno.Icon, 1);
-				if (Mouse.IsOver(iconRect))
-					TooltipHandler.TipRegion(iconRect, xeno.LabelCap);
-
-				iconRect.x -= iconRect.width;
-			}
-
-			curX = iconRect.x;
-		}
-
-		private static void DoIdeologyIcons(ref Rect rect, ref float curX, Cache cache)
-		{
-			if (cache.Pawn.guest == null)
-				return;
-
-			Rect iconRect = new Rect(curX, rect.y, rect.height, rect.height).ContractedBy(1);
-			iconRect.x -= iconRect.width;
-
-			if (cache.Captive)
-			{
-				if (cache.TraderHomeFaction)
-				{
-					GUI.DrawTexture(rect, GuestUtility.RansomIcon);
-					if (Mouse.IsOver(rect))
-					{
-						TooltipHandler.TipRegion(rect, "SellingAsRansom".Translate());
-					}
-				}
-				else
-				{
-					GUI.DrawTexture(rect, GuestUtility.SlaveIcon);
-					if (Mouse.IsOver(rect))
-					{
-						TooltipHandler.TipRegion(rect, "SellingAsSlave".Translate());
-					}
-				}
-				iconRect.x -= iconRect.width;
-			}
+			if (_rowCache.TryGetValue(row, out var cache))
+				cache.Draw(ref rect, row, transactor, ref refresh);
 		}
 	}
 }


### PR DESCRIPTION
This PR adds support for [Random's Gene Assistant](https://steamcommunity.com/sharedfiles/filedetails/?id=2882497271). The patch works by taking the base game genepack icon (or a retexture if one is available) and shading it red/yellow/green using the same logic as Gene Assistant. It then applies that icon to genepacks in the extra icons column. The diff for this PR looks gnarly because the extra icons column was only architected with pawns in mind, so I had to abstract icon drawing into an interface (`ITradeable`) which is then implemented depending on the thing being sold in the row (`PawnTradeable` and `GenepackTradeable`). Here is a preview of what it looks like in game: 
![image2](https://github.com/Zeracronius/DynamicTradeInterface/assets/10575995/44a0f384-dc7f-4b3d-9e10-3fb00cfc1e39)
