### PR TITLE
Caravan widget fix for the Vehicle Framework

### DIFF
--- a/Source/DynamicTradeInterface/Mod/Logging.cs
+++ b/Source/DynamicTradeInterface/Mod/Logging.cs
@@ -17,6 +17,11 @@ namespace DynamicTradeInterface.Mod
 			Log.Error(PREFIX + message);
 		}
 
+		internal static void ErrorOnce(string message)
+		{
+			Log.ErrorOnce(PREFIX + message, message.GetHashCode());
+		}
+
 		internal static void Error(Exception exception)
 		{
 			Log.Error(PREFIX + exception);


### PR DESCRIPTION
Delay the initialization of the player tile and biome until the caravan widget is about to be drawn. Fixes a null reference exception when using aereal vehicles with the Vehicle Framework.