### PR TITLE
Add support for Vanilla Psycasts Expanded

### DIFF
--- a/Source/DynamicTradeInterface/InterfaceComponents/PsycastsExpanded.cs
+++ b/Source/DynamicTradeInterface/InterfaceComponents/PsycastsExpanded.cs
@@ -1,0 +1,32 @@
+﻿using HarmonyLib;
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using Verse;
+
+namespace DynamicTradeInterface.InterfaceComponents
+{
+	[StaticConstructorOnStartup]
+	internal static class PsycastsExpanded
+	{
+		private static readonly MethodInfo? _isEltexOrHasEltexMaterial = null;
+
+		public static readonly bool Active = false;
+
+		static PsycastsExpanded()
+		{
+			if (ModsConfig.RoyaltyActive && ModsConfig.IsActive("VanillaExpanded.VPsycastsE"))
+			{
+				Type? type = Type.GetType("VanillaPsycastsExpanded.PsycastUtility, VanillaPsycastsExpanded, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null");
+				_isEltexOrHasEltexMaterial = AccessTools.Method(type, "IsEltexOrHasEltexMaterial", new Type[] { typeof(ThingDef) });
+				Active = _isEltexOrHasEltexMaterial != null;
+			}
+		}
+
+		public static bool IsEltexOrHasEltexMaterial(ThingDef thing)
+		{
+			Debug.Assert(Active);
+			return (bool)_isEltexOrHasEltexMaterial!.Invoke(null, new object[] { (object)thing });
+		}
+	}
+}

--- a/Source/DynamicTradeInterface/UserInterface/Columns/ColumnButtons.cs
+++ b/Source/DynamicTradeInterface/UserInterface/Columns/ColumnButtons.cs
@@ -20,11 +20,11 @@ namespace DynamicTradeInterface.UserInterface.Columns
 
 		private class Button
 		{
-			private Tradeable _row;
-			private bool _tradeable;
-			private bool _largeRange;
-			private int _minimum;
-			private int _maximum;
+			private readonly Tradeable _row;
+			private readonly bool _tradeable;
+			private readonly bool _largeRange;
+			private readonly int _minimum;
+			private readonly int _maximum;
 
 			public Button(Tradeable row)
 			{

--- a/Source/DynamicTradeInterface/UserInterface/Columns/ColumnButtons.cs
+++ b/Source/DynamicTradeInterface/UserInterface/Columns/ColumnButtons.cs
@@ -15,13 +15,216 @@ namespace DynamicTradeInterface.UserInterface.Columns
 {
 	internal static class ColumnButtons
 	{
-		private static Dictionary<Tradeable, (bool, bool, int, int)> _editableCache = new Dictionary<Tradeable, (bool, bool, int, int)>();
+		private static Dictionary<Tradeable, Button> _editableCache = new Dictionary<Tradeable, Button>();
 		private static Mod.DynamicTradeInterfaceSettings? _settings;
+
+		private class Button
+		{
+			private Tradeable _row;
+			private bool _tradeable;
+			private bool _largeRange;
+			private int _minimum;
+			private int _maximum;
+
+			public Button(Tradeable row)
+			{
+				_row = row;
+				_tradeable = row.TraderWillTrade == true && row.Interactive == true;
+				_largeRange = row.GetRange() > 1;
+				_minimum = row.GetMinimumToTransfer();
+				_maximum = row.GetMaximumToTransfer();
+			}
+
+			public void Draw(ref Rect rect, Transactor transactor, ref bool refresh)
+			{
+				if (!_tradeable)
+					return;
+
+				int currentAmountToTransfer = _row.CountToTransfer;
+
+				if (_settings?.GhostButtons == true && currentAmountToTransfer == 0 && Mouse.IsOver(rect.ExpandedBy(rect.width / 2, rect.height * 2)) == false)
+					return;
+
+				TransferablePositiveCountDirection positiveDirection = _row.PositiveCountDirection;
+
+				int baseCount = positiveDirection == TransferablePositiveCountDirection.Source ? 1 : -1;
+
+				// Source is left.
+				int adjustMultiplier = GenUI.CurrentAdjustmentMultiplier();
+				int adjustAmount = baseCount * adjustMultiplier;
+
+				float gap = 2;
+				// << < 0 > >>
+				float width = rect.width / 5 - gap;
+				Rect baseButtonRect = new Rect(rect.x, rect.y, width, rect.height);
+
+				// Draw left arrows
+				Rect button = new Rect(baseButtonRect);
+				if (CanAdjustBy(adjustAmount, currentAmountToTransfer)) {
+					if (_largeRange) {
+						if (Widgets.ButtonText(button, "<<") || DragSelect.IsPainting(button, DragSelect.PaintingDirection.Left)) {
+							if (positiveDirection == TransferablePositiveCountDirection.Source) {
+								BuyMore();
+							} else {
+								SellMore();
+							}
+							refresh = true;
+							SoundDefOf.Tick_High.PlayOneShotOnCamera();
+						}
+						button.x += button.width + gap;
+					} else {
+						button.width += gap + baseButtonRect.width;
+					}
+
+					if (Widgets.ButtonText(button, "<") || (!_largeRange && DragSelect.IsPainting(button, DragSelect.PaintingDirection.Left))) {
+						_row.AdjustBy(adjustAmount);
+						refresh = true;
+						SoundDefOf.Tick_High.PlayOneShotOnCamera();
+					}
+					baseButtonRect.x = button.xMax + gap;
+				} else {
+					baseButtonRect.x += baseButtonRect.width * 2 + gap * 2;
+				}
+
+				// Draw reset
+				if (currentAmountToTransfer != 0) {
+					if (Widgets.ButtonText(baseButtonRect, "0") || DragSelect.IsPainting(baseButtonRect, DragSelect.PaintingDirection.Middle)) {
+						_row.AdjustTo(0);
+						refresh = true;
+						SoundDefOf.Tick_Low.PlayOneShotOnCamera();
+					}
+				}
+				baseButtonRect.x += baseButtonRect.width + gap;
+
+				// Draw right arrows
+				if (CanAdjustBy(-adjustAmount, currentAmountToTransfer)) {
+					if (_largeRange == false)
+						baseButtonRect.width = baseButtonRect.width * 2 + gap;
+
+
+					if (Widgets.ButtonText(baseButtonRect, ">") || (!_largeRange && DragSelect.IsPainting(baseButtonRect, DragSelect.PaintingDirection.Right))) {
+						_row.AdjustBy(-adjustAmount);
+						refresh = true;
+						SoundDefOf.Tick_Low.PlayOneShotOnCamera();
+
+					}
+					baseButtonRect.x += baseButtonRect.width + gap;
+
+					if (_largeRange) {
+						if (Widgets.ButtonText(baseButtonRect, ">>") || DragSelect.IsPainting(baseButtonRect, DragSelect.PaintingDirection.Right)) {
+							if (positiveDirection == TransferablePositiveCountDirection.Source) {
+								SellMore();
+							} else {
+								BuyMore();
+							}
+							refresh = true;
+							SoundDefOf.Tick_Low.PlayOneShotOnCamera();
+						}
+					}
+				}
+			}
+
+			private bool CanAdjustBy(int target, int current)
+			{
+				int total = current + target;
+				if (total < _minimum || total > _maximum)
+					return false;
+
+				return true;
+			}
+
+			/// <summary>
+			/// max sellable ← can sell ← 0 ← can buy ← max buyable
+			/// </summary>
+			/// <param name="row">The item in question.</param>
+			private void SellMore()
+			{
+				if (TradeSession.giftMode || Event.current.shift) {
+					_row.AdjustTo(_row.GetMinimumToTransfer());
+					return;
+				}
+
+				int currentAmount = _row.CountToTransfer;
+				if (currentAmount > 0) {
+					BuyLess(currentAmount);
+					return;
+				}
+
+				int traderCanBuy = MaxAmount(TradeAction.PlayerSells);
+				if (currentAmount > traderCanBuy)
+					_row.AdjustTo(traderCanBuy);
+				else
+					_row.AdjustTo(_row.GetMinimumToTransfer());
+			}
+
+			/// <summary>
+			/// max sellable → can sell → 0
+			/// </summary>
+			/// <param name="row">The item in question.</param>
+			private void SellLess(int currentAmount)
+			{
+				int traderCanBuy = MaxAmount(TradeAction.PlayerSells);
+				if (currentAmount < traderCanBuy)
+					_row.AdjustTo(traderCanBuy);
+				else
+					_row.AdjustTo(0);
+			}
+
+			/// <summary>
+			/// max sellable → can sell → 0 → can buy → max buyable
+			/// </summary>
+			/// <param name="row">The item in question.</param>
+			private void BuyMore()
+			{
+				if (TradeSession.giftMode || Event.current.shift) {
+					_row.AdjustTo(_row.GetMaximumToTransfer());
+					return;
+				}
+
+				int currentAmount = _row.CountToTransfer;
+				if (currentAmount < 0) {
+					SellLess(currentAmount);
+					return;
+				}
+
+				int colonyCanBuy = MaxAmount(TradeAction.PlayerBuys);
+
+				// If current value is below what the colony can buy, stop at that first.
+				if (currentAmount < colonyCanBuy)
+					_row.AdjustTo(colonyCanBuy);
+				else
+					_row.AdjustTo(_row.GetMaximumToTransfer());
+			}
+
+			/// <summary>
+			/// 0 ← can buy ← max buyable
+			/// </summary>
+			/// <param name="row">The item in question.</param>
+			private void BuyLess(int currentAmount)
+			{
+				int traderCanBuy = MaxAmount(TradeAction.PlayerBuys);
+				if (currentAmount > traderCanBuy)
+					_row.AdjustTo(traderCanBuy);
+				else
+					_row.AdjustTo(0);
+			}
+
+			private int MaxAmount(TradeAction action)
+			{
+				Transactor transactor = Transactor.Colony;
+				if (action == TradeAction.PlayerSells)
+					transactor = Transactor.Trader;
+
+				float price = _row.GetPriceFor(action);
+				int currency = TradeSession.deal.CurrencyTradeable.CountPostDealFor(transactor);
+				return (int)(currency / price);
+			}
+		}
 
 		public static void PostOpen(IEnumerable<Tradeable> rows, Transactor transactor)
 		{
 			foreach (var row in rows)
-				_editableCache[row] = (row.TraderWillTrade == true && row.Interactive == true, row.GetRange() > 1, row.GetMinimumToTransfer(), row.GetMaximumToTransfer());
+				_editableCache[row] = new Button(row);
 
 			_settings = Mod.DynamicTradeInterfaceMod.Settings;
 		}
@@ -37,216 +240,8 @@ namespace DynamicTradeInterface.UserInterface.Columns
 		public static void Draw(ref Rect rect, Tradeable row, Transactor transactor, ref bool refresh)
 		{
 			// Can edit?
-			if (_editableCache.TryGetValue(row, out (bool, bool, int, int) cached) == false)
-				return;
-
-			if (cached.Item1 == false)
-				return;
-
-			int currentAmountToTransfer = row.CountToTransfer;
-
-			if (_settings?.GhostButtons == true && currentAmountToTransfer == 0 && Mouse.IsOver(rect.ExpandedBy(rect.width / 2, rect.height * 2)) == false)
-				return;
-
-			TransferablePositiveCountDirection positiveDirection = row.PositiveCountDirection;
-
-			int baseCount = positiveDirection == TransferablePositiveCountDirection.Source ? 1 : -1;
-
-			// Source is left.
-			int adjustMultiplier = GenUI.CurrentAdjustmentMultiplier();
-			int adjustAmount = baseCount * adjustMultiplier;
-			bool largeRange = cached.Item2;
-
-			float gap = 2;
-			// << < 0 > >>
-			float width = rect.width / 5 - gap;
-			Rect baseButtonRect = new Rect(rect.x, rect.y, width, rect.height);
-
-			// Draw left arrows
-			Rect button = new Rect(baseButtonRect);
-			if (CanAdjustBy(adjustAmount, currentAmountToTransfer, cached.Item3, cached.Item4))
-			{
-				if (largeRange)
-				{
-					if (Widgets.ButtonText(button, "<<") || DragSelect.IsPainting(button, DragSelect.PaintingDirection.Left))
-					{
-						if (positiveDirection == TransferablePositiveCountDirection.Source)
-						{
-							BuyMore(row);
-						}
-						else
-						{
-							SellMore(row);
-						}
-						refresh = true;
-						SoundDefOf.Tick_High.PlayOneShotOnCamera();
-					}
-					button.x += button.width + gap;
-				}
-				else
-				{
-					button.width += gap + baseButtonRect.width;
-				}
-
-				if (Widgets.ButtonText(button, "<") || (!largeRange && DragSelect.IsPainting(button, DragSelect.PaintingDirection.Left)))
-				{
-					row.AdjustBy(adjustAmount);
-					refresh = true;
-					SoundDefOf.Tick_High.PlayOneShotOnCamera();
-				}
-				baseButtonRect.x = button.xMax + gap;
-			}
-			else
-			{
-				baseButtonRect.x += baseButtonRect.width * 2 + gap * 2;
-			}
-
-			// Draw reset
-			if (currentAmountToTransfer != 0)
-			{
-				if (Widgets.ButtonText(baseButtonRect, "0") || DragSelect.IsPainting(baseButtonRect, DragSelect.PaintingDirection.Middle))
-				{
-					row.AdjustTo(0);
-					refresh = true;
-					SoundDefOf.Tick_Low.PlayOneShotOnCamera();
-				}
-			}
-			baseButtonRect.x += baseButtonRect.width + gap;
-
-			// Draw right arrows
-			if (CanAdjustBy(-adjustAmount, currentAmountToTransfer, cached.Item3, cached.Item4))
-			{
-				if (largeRange == false)
-					baseButtonRect.width = baseButtonRect.width * 2 + gap;
-
-
-				if (Widgets.ButtonText(baseButtonRect, ">") || (!largeRange && DragSelect.IsPainting(baseButtonRect, DragSelect.PaintingDirection.Right)))
-				{
-					row.AdjustBy(-adjustAmount);
-					refresh = true;
-					SoundDefOf.Tick_Low.PlayOneShotOnCamera();
-
-				}
-				baseButtonRect.x += baseButtonRect.width + gap;
-
-				if (largeRange)
-				{
-					if (Widgets.ButtonText(baseButtonRect, ">>") || DragSelect.IsPainting(baseButtonRect, DragSelect.PaintingDirection.Right))
-					{
-						if (positiveDirection == TransferablePositiveCountDirection.Source)
-						{
-							SellMore(row);
-						}
-						else
-						{
-							BuyMore(row);
-						}
-						refresh = true;
-						SoundDefOf.Tick_Low.PlayOneShotOnCamera();
-					}
-				}
-			}
-		}
-
-		private static bool CanAdjustBy(int target, int current, int minimum, int maximum)
-		{
-			int total = current + target;
-			if (total < minimum || total > maximum)
-				return false;
-
-			return true;
-		}
-
-		/// <summary>
-		/// max sellable ← can sell ← 0 ← can buy ← max buyable
-		/// </summary>
-		/// <param name="row">The item in question.</param>
-		private static void SellMore(Tradeable row)
-		{
-			if (TradeSession.giftMode || Event.current.shift)
-			{
-				row.AdjustTo(row.GetMinimumToTransfer());
-				return;
-			}
-
-			int currentAmount = row.CountToTransfer;
-			if (currentAmount > 0)
-			{
-				BuyLess(row, currentAmount);
-				return;
-			}
-
-			int traderCanBuy = MaxAmount(row, TradeAction.PlayerSells);
-			if (currentAmount > traderCanBuy)
-				row.AdjustTo(traderCanBuy);
-			else
-				row.AdjustTo(row.GetMinimumToTransfer());
-		}
-
-		/// <summary>
-		/// max sellable → can sell → 0
-		/// </summary>
-		/// <param name="row">The item in question.</param>
-		private static void SellLess(Tradeable row, int currentAmount)
-		{
-			int traderCanBuy = MaxAmount(row, TradeAction.PlayerSells);
-			if (currentAmount < traderCanBuy)
-				row.AdjustTo(traderCanBuy);
-			else
-				row.AdjustTo(0);
-		}
-
-		/// <summary>
-		/// max sellable → can sell → 0 → can buy → max buyable
-		/// </summary>
-		/// <param name="row">The item in question.</param>
-		private static void BuyMore(Tradeable row)
-		{
-			if (TradeSession.giftMode || Event.current.shift)
-			{
-				row.AdjustTo(row.GetMaximumToTransfer());
-				return;
-			}
-
-			int currentAmount = row.CountToTransfer;
-			if (currentAmount < 0)
-			{
-				SellLess(row, currentAmount);
-				return;
-			}
-
-			int colonyCanBuy = MaxAmount(row, TradeAction.PlayerBuys);
-
-			// If current value is below what the colony can buy, stop at that first.
-			if (currentAmount < colonyCanBuy)
-				row.AdjustTo(colonyCanBuy);
-			else
-				row.AdjustTo(row.GetMaximumToTransfer());
-		}
-
-		/// <summary>
-		/// 0 ← can buy ← max buyable
-		/// </summary>
-		/// <param name="row">The item in question.</param>
-		private static void BuyLess(Tradeable row, int currentAmount)
-		{
-			int traderCanBuy = MaxAmount(row, TradeAction.PlayerBuys);
-			if (currentAmount > traderCanBuy)
-				row.AdjustTo(traderCanBuy);
-			else
-				row.AdjustTo(0);
-		}
-
-
-		private static int MaxAmount(Tradeable row, TradeAction action)
-		{
-			Transactor transactor = Transactor.Colony;
-			if (action == TradeAction.PlayerSells)
-				transactor = Transactor.Trader;
-
-			float price = row.GetPriceFor(action);
-			int currency = TradeSession.deal.CurrencyTradeable.CountPostDealFor(transactor);
-			return (int)(currency / price);
+			if (_editableCache.TryGetValue(row, out Button button))
+				button.Draw(ref rect, transactor, ref refresh);
 		}
 	}
 }


### PR DESCRIPTION
This PR add support for [Vanilla Psycasts Expanded](https://steamcommunity.com/sharedfiles/filedetails/?id=2842502659). This mod has a mechanic where the player has a chance to lose goodwill if they sell eltex to any non-empire faction. A [harmony patch](https://github.com/Vanilla-Expanded/VanillaPsycastsExpanded/blob/f6c01c9a8642cc626421446acbea573d9865e400/1.4/Source/VanillaPsycastsExpanded/HarmonyPatches/Transferable_CanAdjustBy_Patch.cs) is utilized to check if the player is selling eltex, and warns them if they are. This patch only works if `Transferable.CanAdjustBy` is called, but you've bypassed that, so the patch fails. This PR adds support for that warning.

For convenience, I have split the rendering of each button cell into its own class (`ColumnButtons.Button`) which gives me access to class fields for each cell, and simplifies what would otherwise have been a messy patch.